### PR TITLE
feat: Implement SKU name deduplication and prepare for mouseover

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,7 +17,7 @@ logging.debug(f"Attributes in st: {dir(st)}")
 
 # Import functions and classes from new modules
 from gemini_service import run_gemini_extraction
-from sku_processing import preprocess_data, generate_comparison_table
+from sku_processing import preprocess_data, generate_comparison_table, normalize_sku_names # Added normalize_sku_names
 from ui_components import (
     render_file_uploader,
     render_sku_selector,
@@ -28,6 +28,29 @@ from ui_components import (
     render_footer,
 )
 from models import ProcessedSkuItem # Import ProcessedSkuItem for type hinting if needed, or just for clarity
+import instructor
+from openai import OpenAI # For instructor client
+
+# --- Initialize Chutes AI Instructor Client ---
+# Attempt to get API key from Streamlit secrets, then environment variable
+CHUTES_API_KEY = st.secrets.get("CHUTES_API_KEY", os.environ.get("CHUTES_API_KEY"))
+chutes_instructor_client = None
+if CHUTES_API_KEY:
+    try:
+        chutes_instructor_client = instructor.from_openai(
+            OpenAI(
+                base_url="https://llm.chutes.ai/v1/",
+                api_key=CHUTES_API_KEY,
+                timeout=30.0, # Added timeout
+            )
+        )
+        logging.info("Chutes AI Instructor client initialized successfully.")
+    except Exception as e:
+        logging.error(f"Failed to initialize Chutes AI Instructor client: {e}")
+        # chutes_instructor_client will remain None, app can proceed without normalization if client is None
+else:
+    logging.warning("CHUTES_API_KEY not found in Streamlit secrets or environment variables. SKU normalization will be skipped.")
+
 
 # --- Streamlit App UI ---
 st.set_page_config(layout="wide")
@@ -86,10 +109,43 @@ def handle_extract_data(uploaded_files):
         processed_items = preprocess_data(st.session_state.extracted_data)
         if processed_items:
             st.session_state.processed_items = processed_items
-            unique_sku_names = sorted(list(set(item.sku_name for item in processed_items)))
+            
+            # --- SKU Name Normalization Step ---
+            if chutes_instructor_client and st.session_state.processed_items:
+                current_sku_names = sorted(list(set(item.sku_name for item in st.session_state.processed_items)))
+                if current_sku_names:
+                    st.write("Normalizing SKU names via Chutes AI...") # User feedback
+                    try:
+                        normalized_name_map = normalize_sku_names(current_sku_names, chutes_instructor_client)
+
+                        if normalized_name_map:
+                            updated_items_count = 0
+                            for item in st.session_state.processed_items:
+                                original_name = item.sku_name
+                                normalized_name = normalized_name_map.get(original_name, original_name)
+                                if original_name != normalized_name:
+                                    item.sku_name = normalized_name
+                                    updated_items_count +=1
+                            if updated_items_count > 0:
+                                st.success(f"SKU names normalized. {updated_items_count} items updated.")
+                            else:
+                                st.info("SKU name normalization complete. No names were changed by the LLM.")
+                        else:
+                            st.warning("SKU name normalization did not return any mappings. Using original names.")
+                    except Exception as e:
+                        st.error(f"Error during SKU name normalization: {e}. Proceeding with original names.")
+                        logging.error(f"SKU Normalization Exception: {e}", exc_info=True)
+                else:
+                    logging.info("No SKU names found in processed items to normalize.")
+            elif not chutes_instructor_client:
+                st.warning("Chutes AI client not initialized (CHUTES_API_KEY missing?). Skipping SKU name normalization.")
+            # --- End SKU Name Normalization ---
+
+            # Update all_sku_names and selected_sku_names with the new (potentially normalized) names
+            unique_sku_names = sorted(list(set(item.sku_name for item in st.session_state.processed_items)))
             st.session_state.all_sku_names = unique_sku_names
-            # Preselect all SKUs after extraction
-            st.session_state.selected_sku_names = unique_sku_names.copy()
+            # Preselect all SKUs after extraction/normalization
+            st.session_state.selected_sku_names = unique_sku_names.copy() # Ensure this is a copy
         else:
             st.warning("No processable items found after initial parsing of Gemini data.")
     else:

--- a/models.py
+++ b/models.py
@@ -32,3 +32,15 @@ class ProcessedSkuItem:
     comparison_eff_rate: Optional[float] = None
     calculated_rate_per_qty: Optional[float] = None
     batch_number: str = "N/A"
+
+from pydantic import BaseModel, Field
+from typing import List
+
+class SkuNameMapping(BaseModel):
+    """Represents a mapping from an original SKU name to its normalized form."""
+    original_sku_name: str = Field(description="The original SKU name extracted from the document")
+    normalized_sku_name: str = Field(description="The canonical or deduplicated form of the SKU name")
+
+class BatchSkuNameNormalization(BaseModel):
+    """Represents a batch of SKU name normalizations, mapping multiple original names to their canonical forms."""
+    mappings: List[SkuNameMapping] = Field(description="List of SKU name normalizations")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 streamlit
 pandas
 google-genai
+instructor
+openai


### PR DESCRIPTION
This commit introduces a SKU name deduplication step in the quotation comparison service.

Key changes:
- Added Pydantic models `SkuNameMapping` and `BatchSkuNameNormalization` to `models.py` for handling SKU name normalization.
- Implemented a `normalize_sku_names` function in `sku_processing.py`. This function uses an external LLM via the `instructor` library (Chutes AI endpoint) to normalize a list of SKU names, grouping similar ones.
- Integrated this normalization step into `app.py`. After initial data extraction and preprocessing, SKU names are sent for normalization. The `ProcessedSkuItem` list is then updated with these normalized names. Original SKU codes (`item.sku`) are preserved.
- Updated `generate_comparison_table` in `sku_processing.py` to include an 'Original SKUs' column. This column contains a comma-separated string of original SKU codes that were mapped to the normalized SKU name, enabling a future mouseover feature in the UI to display these original codes.
- The `instructor` client is initialized in `app.py` using an API key from Streamlit secrets (`CHUTES_API_KEY`).
- Error handling has been added to gracefully manage potential failures during the normalization API call, falling back to original SKU names if needed.
- Ensured `instructor` and `openai` are listed in `requirements.txt`.

This addresses the issue of duplicate SKU names arising from parallel Gemini API calls and provides the backend support for displaying original SKU details in the UI.